### PR TITLE
Fix #4461 HttpOutput Aggregation (#4466)

### DIFF
--- a/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/HttpOutput.java
@@ -378,6 +378,18 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         return wake;
     }
 
+    private int maximizeAggregateSpace()
+    {
+        // If no aggregate, we can allocate one of bufferSize
+        if (_aggregate == null)
+            return getBufferSize();
+
+        // compact to maximize space
+        BufferUtil.compact(_aggregate);
+
+        return BufferUtil.space(_aggregate);
+    }
+
     public void softClose()
     {
         synchronized (_channelState)
@@ -723,6 +735,9 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     @Override
     public void write(byte[] b, int off, int len) throws IOException
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("write(array {})", BufferUtil.toDetailString(ByteBuffer.wrap(b, off, len)));
+
         boolean last;
         boolean aggregate;
         boolean flush;
@@ -733,7 +748,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         {
             checkWritable();
             long written = _written + len;
-            int space = _aggregate == null ? getBufferSize() : BufferUtil.space(_aggregate);
+            int space = maximizeAggregateSpace();
             last = _channel.getResponse().isAllContentWritten(written);
             // Write will be aggregated if:
             //  + it is smaller than the commitSize
@@ -777,13 +792,22 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
                 // return if we are not complete, not full and filled all the content
                 if (!flush)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("write(array) {} aggregated !flush {}",
+                            stateString(), BufferUtil.toDetailString(_aggregate));
                     return;
+                }
 
                 // adjust offset/length
                 off += filled;
                 len -= filled;
             }
         }
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("write(array) {} last={} agg={} flush=true async={}, len={} {}",
+                stateString(), last, aggregate, async, len, BufferUtil.toDetailString(_aggregate));
 
         if (async)
         {
@@ -801,9 +825,10 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 channelWrite(_aggregate, last && len == 0);
 
                 // should we fill aggregate again from the buffer?
-                if (len > 0 && !last && len <= _commitSize && len <= BufferUtil.space(_aggregate))
+                if (len > 0 && !last && len <= _commitSize && len <= maximizeAggregateSpace())
                 {
                     BufferUtil.append(_aggregate, b, off, len);
+                    onWriteComplete(false, null);
                     return;
                 }
             }
@@ -929,7 +954,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         {
             checkWritable();
             long written = _written + 1;
-            int space = _aggregate == null ? getBufferSize() : BufferUtil.space(_aggregate);
+            int space = maximizeAggregateSpace();
             last = _channel.getResponse().isAllContentWritten(written);
             flush = last || space == 1;
 
@@ -1602,7 +1627,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         private final ByteBuffer _buffer;
         private final ByteBuffer _slice;
         private final int _len;
-        volatile boolean _completed;
+        private boolean _completed;
 
         AsyncWrite(byte[] b, int off, int len, boolean last)
         {
@@ -1639,7 +1664,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             }
 
             // Can we just aggregate the remainder?
-            if (!_last && _len < BufferUtil.space(_aggregate) && _len < _commitSize)
+            if (!_last && _aggregate != null && _len < maximizeAggregateSpace() && _len < _commitSize)
             {
                 int position = BufferUtil.flipToFill(_aggregate);
                 BufferUtil.put(_buffer, _aggregate);
@@ -1846,32 +1871,16 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
     private class WriteCompleteCB implements Callback
     {
-        final Callback _callback;
-
-        WriteCompleteCB()
-        {
-            this(null);
-        }
-
-        WriteCompleteCB(Callback callback)
-        {
-            _callback = callback;
-        }
-
         @Override
         public void succeeded()
         {
             onWriteComplete(true, null);
-            if (_callback != null)
-                _callback.succeeded();
         }
 
         @Override
         public void failed(Throwable x)
         {
             onWriteComplete(true, x);
-            if (_callback != null)
-                _callback.succeeded();
         }
     }
 }

--- a/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
+++ b/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHttpOutputInterceptor.java
@@ -381,7 +381,7 @@ public class GzipHttpOutputInterceptor implements HttpOutput.Interceptor
                         int len = slice.remaining();
                         _crc.update(array, off, len);
                         _deflater.setInput(array, off, len);  // TODO use ByteBuffer API in Jetty-10
-                        BufferUtil.clear(slice);
+                        slice.position(slice.position() + len);
                         if (_last && BufferUtil.isEmpty(_content))
                             _deflater.finish();
                     }


### PR DESCRIPTION
* Issue #4461 HttpOutput Aggregation

Added tests to check that aggregation continues after first flush of an aggregated buffer (this triggers both #4461 and the discovered bug of not aggregating because of empty at capacity aggregate buffer).

Added getAggregateSize method that does a compact to avoid empty at capacity aggregate buffer

Call onWriteComplete if residue of an overflow aggregation can itself be aggregated.

Signed-off-by: Greg Wilkins <gregw@webtide.com>

* Issue #4461 HttpOutput Aggregation

Removed implicit compact from GzipHandler

Signed-off-by: Greg Wilkins <gregw@webtide.com>

* Issue #4461 HttpOutput Aggregation

Improve test coverage

Signed-off-by: Greg Wilkins <gregw@webtide.com>

* Issue #4461 HttpOutput Aggregation

Remove case that can never happen.

Signed-off-by: Greg Wilkins <gregw@webtide.com>

* Issue #4461 HttpOutput Aggregation

updates from review

Signed-off-by: Greg Wilkins <gregw@webtide.com>